### PR TITLE
Make the font crispy by disabling smoothing.

### DIFF
--- a/piOStheme.css
+++ b/piOStheme.css
@@ -14,11 +14,17 @@ https://gist.github.com/ExperiBass/2375ac4f7088bb9410d81cd59495f462
 
 @font-face {
     font-family: "FixedSysTrue";
+    font-smooth: none;
+    -webkit-font-smoothing: none;
+    -moz-osx-font-smoothing: none;
     src: url("https://saltssaumure.github.io/pios-discord-theme/fonts/FixedSysTrue.ttf")
 }
 
 @font-face {
     font-family: "PerfectDOS";
+    font-smooth: none;
+    -webkit-font-smoothing: none;
+    -moz-osx-font-smoothing: none;
     src: url("https://saltssaumure.github.io/pios-discord-theme/fonts/PerfectDosVga.ttf")
 }
 


### PR DESCRIPTION
This improves display of the theme, as the fonts are now crisper.